### PR TITLE
Enhancements for multiple stateMachines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+### Changelog
+
+All notable changes to this project will be documented in this file. Dates are displayed in UTC.
+
+#### [2.0.3]
+
+- Fixed the endState bug while constructing a stateMachine
+- Introduced a StateMachineBuilder to construct a stateMachine from a configuration, to reduce verbosity
+- Introduced a StateMachineRegistry to create multiple stateMachines atop multiple MachineBuilderConfigurations, making multiple stateMachine creations simple.
+- Introduced a CHANGELOG

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Use the following maven dependency
 <dependency>
   <groupId>com.grookage.fsm</groupId>
   <artifactId>fsm</artifactId>
-  <version>2.0.2</version>
+  <version>2.0.3</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -259,5 +259,5 @@
 
   <url>https://github.com/grookage/easy-fsm</url>
 
-  <version>2.0.2</version>
+  <version>2.0.3</version>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -58,20 +58,20 @@
         <version>3.2.0</version>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
+        <version>3.6.3</version>
         <configuration>
-          <source>11</source>
+          <doclint>all,-missing</doclint>
         </configuration>
         <executions>
           <execution>
+            <id>attach-javadocs</id>
             <goals>
               <goal>jar</goal>
             </goals>
-            <id>attach-javadocs</id>
           </execution>
         </executions>
-        <groupId>org.apache.maven.plugins</groupId>
-        <version>3.3.0</version>
       </plugin>
     </plugins>
   </build>

--- a/src/main/java/com/grookage/fsm/core/StateMachine.java
+++ b/src/main/java/com/grookage/fsm/core/StateMachine.java
@@ -30,27 +30,33 @@ import com.grookage.fsm.core.services.ActionService;
 import com.grookage.fsm.core.services.StateManagementService;
 import com.grookage.fsm.core.services.TransitionService;
 import java.util.Collection;
+import java.util.Locale;
+
 import lombok.Data;
 import lombok.Getter;
 import lombok.SneakyThrows;
+import lombok.experimental.SuperBuilder;
 import lombok.extern.slf4j.Slf4j;
 
 @Data
 @Slf4j
 @Getter
-public abstract class StateMachine<S extends State, E extends Event, K extends TransitionKey, C extends Context<S, E, K>> {
+public class StateMachine<S extends State, E extends Event, K extends TransitionKey, C extends Context<S, E, K>> {
 
+  private final String name;
   private final StateEngine<E, S, K, C> stateEngine;
   private final TransitionProcessorHub<S, E, K, C> transitionProcessorHub;
   private final ErrorAction<E, S, K, C> errorAction;
   private final EventAction<E, S, K, C> eventAction;
 
-  protected StateMachine(
+  public StateMachine(
+      final String name,
       final S startState,
       final TransitionProcessorHub<S, E, K, C> transitionProcessorHub,
       final ErrorAction<E, S, K, C> errorAction,
       final EventAction<E, S, K, C> eventAction
   ) {
+    this.name = name.toUpperCase(Locale.ROOT);
     this.stateEngine = new StateEngine<>(
         startState,
         new TransitionService<>(),

--- a/src/main/java/com/grookage/fsm/core/StateMachine.java
+++ b/src/main/java/com/grookage/fsm/core/StateMachine.java
@@ -19,24 +19,19 @@ import com.google.common.base.Preconditions;
 import com.grookage.fsm.core.action.DefaultErrorAction;
 import com.grookage.fsm.core.engine.StateEngine;
 import com.grookage.fsm.core.hubs.TransitionProcessorHub;
-import com.grookage.fsm.core.models.entities.Context;
-import com.grookage.fsm.core.models.entities.Event;
-import com.grookage.fsm.core.models.entities.State;
-import com.grookage.fsm.core.models.entities.Transition;
-import com.grookage.fsm.core.models.entities.TransitionKey;
+import com.grookage.fsm.core.models.entities.*;
 import com.grookage.fsm.core.models.executors.ErrorAction;
 import com.grookage.fsm.core.models.executors.EventAction;
 import com.grookage.fsm.core.services.ActionService;
 import com.grookage.fsm.core.services.StateManagementService;
 import com.grookage.fsm.core.services.TransitionService;
-import java.util.Collection;
-import java.util.Locale;
-
 import lombok.Data;
 import lombok.Getter;
 import lombok.SneakyThrows;
-import lombok.experimental.SuperBuilder;
 import lombok.extern.slf4j.Slf4j;
+
+import java.util.Collection;
+import java.util.Locale;
 
 @Data
 @Slf4j

--- a/src/main/java/com/grookage/fsm/core/StateMachineBuilder.java
+++ b/src/main/java/com/grookage/fsm/core/StateMachineBuilder.java
@@ -24,7 +24,6 @@ import com.grookage.fsm.core.models.entities.State;
 import com.grookage.fsm.core.models.entities.TransitionKey;
 import com.grookage.fsm.core.models.executors.ErrorAction;
 import com.grookage.fsm.core.models.executors.EventAction;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 

--- a/src/main/java/com/grookage/fsm/core/StateMachineBuilder.java
+++ b/src/main/java/com/grookage/fsm/core/StateMachineBuilder.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2022 Koushik R <rkoushik.14@gmail.com>.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.grookage.fsm.core;
+
+import com.google.common.base.Preconditions;
+import com.grookage.fsm.core.config.MachineBuilderConfig;
+import com.grookage.fsm.core.hubs.TransitionProcessorHub;
+import com.grookage.fsm.core.models.entities.Context;
+import com.grookage.fsm.core.models.entities.Event;
+import com.grookage.fsm.core.models.entities.State;
+import com.grookage.fsm.core.models.entities.TransitionKey;
+import com.grookage.fsm.core.models.executors.ErrorAction;
+import com.grookage.fsm.core.models.executors.EventAction;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+public class StateMachineBuilder<S extends State, E extends Event, K extends TransitionKey, C extends Context<S, E, K>> {
+
+    private MachineBuilderConfig<S, E> machineBuilderConfig;
+    private TransitionProcessorHub<S, E, K, C> transitionProcessorHub;
+    private ErrorAction<E, S, K, C> errorAction;
+    private EventAction<E, S, K, C> eventAction;
+    @Getter
+    private StateMachine<S,E,K,C> stateMachine;
+
+    public StateMachineBuilder<S, E, K, C> withMachineBuilderConfig(MachineBuilderConfig<S, E> machineBuilderConfig){
+        this.machineBuilderConfig = machineBuilderConfig;
+        return this;
+    }
+
+    public StateMachineBuilder<S, E, K, C> withTransitionProcessorHub(TransitionProcessorHub<S, E, K, C> transitionProcessorHub){
+        this.transitionProcessorHub = transitionProcessorHub;
+        return this;
+    }
+
+    public StateMachineBuilder<S, E, K, C> withEventAction(EventAction<E, S, K, C> eventAction){
+        this.eventAction = eventAction;
+        return this;
+    }
+
+    public StateMachineBuilder<S, E, K, C> withErrorAction(ErrorAction<E, S, K, C> errorAction) {
+        this.errorAction = errorAction;
+        return this;
+    }
+
+    public StateMachine<S,E,K,C> build(){
+        Preconditions.checkNotNull(machineBuilderConfig, "Machine Builder Config can't be null");
+        final var startState = machineBuilderConfig.getStartState();
+        final var endStates = machineBuilderConfig.getEndStates();
+        this.stateMachine = new StateMachine<>(machineBuilderConfig.getName(),
+                startState, transitionProcessorHub, errorAction, eventAction);
+        final var transitionConfigs = machineBuilderConfig.getTransitionConfigs();
+        transitionConfigs.forEach(transitionConfig ->
+                stateMachine.onTransition(transitionConfig.getCausedEvent(), transitionConfig.getFrom(), transitionConfig.getTo()));
+        this.stateMachine.end(endStates);
+        this.stateMachine.start();
+        return stateMachine;
+    }
+}

--- a/src/main/java/com/grookage/fsm/core/StateMachineRegistry.java
+++ b/src/main/java/com/grookage/fsm/core/StateMachineRegistry.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2022 Koushik R <rkoushik.14@gmail.com>.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.grookage.fsm.core;
+
+import com.google.common.base.Preconditions;
+import com.grookage.fsm.core.config.MachineBuilderConfig;
+import com.grookage.fsm.core.hubs.TransitionProcessorHub;
+import com.grookage.fsm.core.models.executors.ErrorAction;
+import com.grookage.fsm.core.models.executors.EventAction;
+import lombok.NoArgsConstructor;
+
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+
+@SuppressWarnings({"rawtypes", "unchecked"})
+@NoArgsConstructor
+public class StateMachineRegistry {
+
+    private Map<String, StateMachine> machineRegistry = new ConcurrentHashMap<>();
+    private List<MachineBuilderConfig> machineBuilderConfigs = new ArrayList<>();
+    private Map<String, ErrorAction> errorRegistry = new ConcurrentHashMap<>();
+    private Map<String, EventAction> eventRegistry = new ConcurrentHashMap<>();
+
+    private Map<String, TransitionProcessorHub> hubs = new ConcurrentHashMap<>();
+
+    public Optional<StateMachine> getMachine(final String name) {
+        return Optional.ofNullable(machineRegistry.get(name.toUpperCase(Locale.ROOT)));
+    }
+
+    public StateMachineRegistry withMachineBuilderConfigs(List<MachineBuilderConfig> machineBuilderConfigs) {
+        this.machineBuilderConfigs = machineBuilderConfigs;
+        return this;
+    }
+
+    public StateMachineRegistry withHub(final String machineName, TransitionProcessorHub transitionProcessorHub){
+        hubs.putIfAbsent(machineName.toUpperCase(Locale.ROOT), transitionProcessorHub);
+        return this;
+    }
+
+    public StateMachineRegistry withEventAction(final String machineName, EventAction eventAction){
+        eventRegistry.putIfAbsent(machineName.toUpperCase(Locale.ROOT), eventAction);
+        return this;
+    }
+
+    public StateMachineRegistry withErrorAction(final String machineName, ErrorAction errorAction) {
+        errorRegistry.putIfAbsent(machineName.toUpperCase(Locale.ROOT), errorAction);
+        return this;
+    }
+
+    public StateMachineRegistry build() {
+        Preconditions.checkArgument(null != machineBuilderConfigs && !machineBuilderConfigs.isEmpty(),
+                "Machine Builder Configs can't be null or empty");
+        machineBuilderConfigs.forEach(machineBuilderConfig -> {
+            final var stateMachine = new StateMachineBuilder<>()
+                    .withMachineBuilderConfig(machineBuilderConfig)
+                    .withTransitionProcessorHub(hubs.get(machineBuilderConfig.getName()))
+                    .withErrorAction(errorRegistry.get(machineBuilderConfig.getName()))
+                    .withEventAction(eventRegistry.get(machineBuilderConfig.getName()))
+                    .build();
+            machineRegistry.putIfAbsent(machineBuilderConfig.getName().toUpperCase(Locale.ROOT), stateMachine);
+        });
+        return this;
+    }
+}

--- a/src/main/java/com/grookage/fsm/core/action/DefaultErrorAction.java
+++ b/src/main/java/com/grookage/fsm/core/action/DefaultErrorAction.java
@@ -21,10 +21,11 @@ import com.grookage.fsm.core.models.entities.Event;
 import com.grookage.fsm.core.models.entities.State;
 import com.grookage.fsm.core.models.entities.TransitionKey;
 import com.grookage.fsm.core.models.executors.ErrorAction;
-import java.util.Objects;
 import lombok.NoArgsConstructor;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
+
+import java.util.Objects;
 
 @Slf4j
 @NoArgsConstructor

--- a/src/main/java/com/grookage/fsm/core/config/MachineBuilderConfig.java
+++ b/src/main/java/com/grookage/fsm/core/config/MachineBuilderConfig.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2022 Koushik R <rkoushik.14@gmail.com>.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.grookage.fsm.core.config;
+
+import com.grookage.fsm.core.models.entities.Event;
+import com.grookage.fsm.core.models.entities.State;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+import java.util.Set;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+public class MachineBuilderConfig<S extends State, E extends Event> {
+
+    @NotEmpty
+    private String name;
+    @NotNull
+    private S startState;
+    @NotNull
+    private Set<S> endStates;
+    @NotEmpty
+    private Set<TransitionConfig<S, E>> transitionConfigs;
+}

--- a/src/main/java/com/grookage/fsm/core/config/TransitionConfig.java
+++ b/src/main/java/com/grookage/fsm/core/config/TransitionConfig.java
@@ -52,8 +52,6 @@ public class TransitionConfig<S extends State, E extends Event> {
 
     @Override
     public int hashCode() {
-        int result = causedEvent.hashCode();
-        result = 31 * result + (causedEvent != null ? causedEvent.hashCode() : 0);
-        return result;
+        return 31 * causedEvent.hashCode();
     }
 }

--- a/src/main/java/com/grookage/fsm/core/config/TransitionConfig.java
+++ b/src/main/java/com/grookage/fsm/core/config/TransitionConfig.java
@@ -16,7 +16,6 @@
 package com.grookage.fsm.core.config;
 
 import com.grookage.fsm.core.models.entities.Event;
-import com.grookage.fsm.core.models.entities.HandlerType;
 import com.grookage.fsm.core.models.entities.State;
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src/main/java/com/grookage/fsm/core/config/TransitionConfig.java
+++ b/src/main/java/com/grookage/fsm/core/config/TransitionConfig.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2022 Koushik R <rkoushik.14@gmail.com>.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.grookage.fsm.core.config;
+
+import com.grookage.fsm.core.models.entities.Event;
+import com.grookage.fsm.core.models.entities.HandlerType;
+import com.grookage.fsm.core.models.entities.State;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Set;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+public class TransitionConfig<S extends State, E extends Event> {
+
+    private E causedEvent;
+    private Set<S> from;
+    private S to;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final var that = (TransitionConfig) o;
+        if (!Objects.equals(causedEvent, that.causedEvent)) {
+            return false;
+        }
+        return Objects.equals(causedEvent.name().toLowerCase(Locale.ROOT),
+                that.causedEvent.name().toUpperCase(Locale.ROOT));
+    }
+
+    @Override
+    public int hashCode() {
+        int result = causedEvent.hashCode();
+        result = 31 * result + (causedEvent != null ? causedEvent.hashCode() : 0);
+        return result;
+    }
+}

--- a/src/main/java/com/grookage/fsm/core/engine/StateEngine.java
+++ b/src/main/java/com/grookage/fsm/core/engine/StateEngine.java
@@ -178,14 +178,14 @@ public class StateEngine<E extends Event, S extends State, K extends TransitionK
 
     for (S state : allStates) {
       var transitions = (Set<Transition<E, S>>) map.get(state);
-      if (isNullOrEmpty(transitions)) {
-        if (!stateManagementService.getEndStates().contains(state)) {
-          throw new InvalidStateException("state :" + state + " is not an end state but"
-              + " has no outgoing transitions");
-        } else if (stateManagementService.getEndStates().contains(state) && !isNullOrEmpty(transitions)) {
-          throw new InvalidStateException("state :" + state + " is an end state"
-              + " and cannot have any out going transition");
+      if(isNullOrEmpty(transitions)){
+        if(!stateManagementService.getEndStates().contains(state)){
+          throw new InvalidStateException("state :"+ state +" is not an end state but"
+                  + " has no outgoing transitions");
         }
+      } else if(stateManagementService.getEndStates().contains(state)){
+        throw new InvalidStateException("state :"+ state +" is an end state"
+                + " and cannot have any out going transition");
       }
     }
   }

--- a/src/main/java/com/grookage/fsm/core/engine/StateEngine.java
+++ b/src/main/java/com/grookage/fsm/core/engine/StateEngine.java
@@ -19,23 +19,19 @@ import com.grookage.fsm.core.action.DefaultErrorAction;
 import com.grookage.fsm.core.exceptions.FsmException;
 import com.grookage.fsm.core.exceptions.InvalidStateException;
 import com.grookage.fsm.core.exceptions.StateNotFoundException;
-import com.grookage.fsm.core.models.entities.Context;
-import com.grookage.fsm.core.models.entities.Event;
-import com.grookage.fsm.core.models.entities.EventType;
-import com.grookage.fsm.core.models.entities.State;
-import com.grookage.fsm.core.models.entities.Transition;
-import com.grookage.fsm.core.models.entities.TransitionKey;
+import com.grookage.fsm.core.models.entities.*;
 import com.grookage.fsm.core.models.executors.ErrorAction;
 import com.grookage.fsm.core.models.executors.EventAction;
 import com.grookage.fsm.core.services.ActionService;
 import com.grookage.fsm.core.services.StateManagementService;
 import com.grookage.fsm.core.services.TransitionService;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+
 import java.util.Collection;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import lombok.SneakyThrows;
-import lombok.extern.slf4j.Slf4j;
 
 /**
  * Entity by : koushikr. on 23/10/15.

--- a/src/main/java/com/grookage/fsm/core/models/entities/Context.java
+++ b/src/main/java/com/grookage/fsm/core/models/entities/Context.java
@@ -17,13 +17,14 @@ package com.grookage.fsm.core.models.entities;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.base.Strings;
-import java.io.Serializable;
-import java.util.Optional;
-import java.util.function.Function;
 import lombok.Data;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+
+import java.io.Serializable;
+import java.util.Optional;
+import java.util.function.Function;
 
 /**
  * Entity by : koushikr. on 23/10/15.

--- a/src/main/java/com/grookage/fsm/core/models/entities/HandlerType.java
+++ b/src/main/java/com/grookage/fsm/core/models/entities/HandlerType.java
@@ -16,6 +16,7 @@
 package com.grookage.fsm.core.models.entities;
 
 import com.grookage.fsm.core.models.executors.EventAction;
+
 import java.util.Objects;
 
 /**

--- a/src/main/java/com/grookage/fsm/core/models/entities/Transition.java
+++ b/src/main/java/com/grookage/fsm/core/models/entities/Transition.java
@@ -15,10 +15,11 @@
  */
 package com.grookage.fsm.core.models.entities;
 
-import java.util.Objects;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
+
+import java.util.Objects;
 
 /**
  * Entity by : koushikr. on 23/10/15.

--- a/src/main/java/com/grookage/fsm/core/models/executors/TransitionProcessor.java
+++ b/src/main/java/com/grookage/fsm/core/models/executors/TransitionProcessor.java
@@ -19,6 +19,7 @@ import com.grookage.fsm.core.models.entities.Context;
 import com.grookage.fsm.core.models.entities.Event;
 import com.grookage.fsm.core.models.entities.State;
 import com.grookage.fsm.core.models.entities.TransitionKey;
+
 import java.util.Set;
 
 public interface TransitionProcessor<S extends State, E extends Event, K extends TransitionKey, C extends Context<S, E, K>> {

--- a/src/main/java/com/grookage/fsm/core/services/ActionService.java
+++ b/src/main/java/com/grookage/fsm/core/services/ActionService.java
@@ -16,19 +16,15 @@
 package com.grookage.fsm.core.services;
 
 import com.grookage.fsm.core.exceptions.FsmException;
-import com.grookage.fsm.core.models.entities.Context;
-import com.grookage.fsm.core.models.entities.Event;
-import com.grookage.fsm.core.models.entities.EventType;
-import com.grookage.fsm.core.models.entities.HandlerType;
-import com.grookage.fsm.core.models.entities.State;
-import com.grookage.fsm.core.models.entities.TransitionKey;
+import com.grookage.fsm.core.models.entities.*;
 import com.grookage.fsm.core.models.executors.Action;
 import com.grookage.fsm.core.models.executors.ErrorAction;
 import com.grookage.fsm.core.models.executors.EventAction;
+import lombok.extern.slf4j.Slf4j;
+
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
-import lombok.extern.slf4j.Slf4j;
 
 /**
  * Entity by : koushikr. on 23/10/15.

--- a/src/main/java/com/grookage/fsm/core/services/StateManagementService.java
+++ b/src/main/java/com/grookage/fsm/core/services/StateManagementService.java
@@ -17,12 +17,13 @@ package com.grookage.fsm.core.services;
 
 import com.google.common.collect.Sets;
 import com.grookage.fsm.core.models.entities.State;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.Set;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Entity by : koushikr. on 23/10/15.

--- a/src/main/java/com/grookage/fsm/core/services/TransitionService.java
+++ b/src/main/java/com/grookage/fsm/core/services/TransitionService.java
@@ -20,9 +20,10 @@ import com.google.common.collect.Multimap;
 import com.grookage.fsm.core.models.entities.Event;
 import com.grookage.fsm.core.models.entities.State;
 import com.grookage.fsm.core.models.entities.Transition;
+import lombok.AllArgsConstructor;
+
 import java.util.Optional;
 import java.util.function.Predicate;
-import lombok.AllArgsConstructor;
 
 /**
  * Entity by : koushikr. on 23/10/15.

--- a/src/test/java/com/grookage/fsm/core/StateMachineBuilderTest.java
+++ b/src/test/java/com/grookage/fsm/core/StateMachineBuilderTest.java
@@ -19,7 +19,6 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.grookage.fsm.core.config.MachineBuilderConfig;
 import com.grookage.fsm.core.exceptions.InvalidStateException;
 import com.grookage.fsm.core.helpers.ResourceHelper;
-import com.grookage.fsm.core.helpers.StateMachineHelper;
 import com.grookage.fsm.core.stubs.*;
 import org.junit.Assert;
 import org.junit.Test;

--- a/src/test/java/com/grookage/fsm/core/StateMachineBuilderTest.java
+++ b/src/test/java/com/grookage/fsm/core/StateMachineBuilderTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2022 Koushik R <rkoushik.14@gmail.com>.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.grookage.fsm.core;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.grookage.fsm.core.config.MachineBuilderConfig;
+import com.grookage.fsm.core.exceptions.InvalidStateException;
+import com.grookage.fsm.core.helpers.ResourceHelper;
+import com.grookage.fsm.core.helpers.StateMachineHelper;
+import com.grookage.fsm.core.stubs.*;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class StateMachineBuilderTest {
+
+    @Test
+    public void testValidStateMachineBuilder() throws Exception {
+        final var machineBuilderConfig = ResourceHelper.getResource("stateMachine.json", new TypeReference<MachineBuilderConfig<TestState, TestEvent>>() {
+        });
+        Assert.assertNotNull(machineBuilderConfig);
+        final var stateMachine = new StateMachineBuilder<TestState, TestEvent, TestTransitionKey, TestContext>()
+                .withMachineBuilderConfig(machineBuilderConfig)
+                .withTransitionProcessorHub(TestHub.builder().build())
+                .build();
+        Assert.assertNotNull(stateMachine);
+    }
+
+    @Test(expected = InvalidStateException.class)
+    public void testForInvalidStateMachine() throws Exception {
+        final var machineBuilderConfig = ResourceHelper.getResource("invalidMachine.json", new TypeReference<MachineBuilderConfig<TestState, TestEvent>>() {
+        });
+        new StateMachineBuilder<TestState, TestEvent, TestTransitionKey, TestContext>()
+                .withMachineBuilderConfig(machineBuilderConfig)
+                .withTransitionProcessorHub(TestHub.builder().build())
+                .build();
+    }
+}

--- a/src/test/java/com/grookage/fsm/core/StateMachineRegistryTest.java
+++ b/src/test/java/com/grookage/fsm/core/StateMachineRegistryTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2022 Koushik R <rkoushik.14@gmail.com>.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.grookage.fsm.core;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.grookage.fsm.core.config.MachineBuilderConfig;
+import com.grookage.fsm.core.helpers.ResourceHelper;
+import com.grookage.fsm.core.stubs.TestEvent;
+import com.grookage.fsm.core.stubs.TestHub;
+import com.grookage.fsm.core.stubs.TestState;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+
+public class StateMachineRegistryTest {
+
+    @Test
+    public void testHub() throws Exception {
+        final var machineBuilderConfig = ResourceHelper.getResource("stateMachine.json", new TypeReference<MachineBuilderConfig<TestState, TestEvent>>() {
+        });
+        final var machineBuilderConfig2 = ResourceHelper.getResource("stateMachine2.json", new TypeReference<MachineBuilderConfig<TestState, TestEvent>>() {
+        });
+        final var machineRegistry = new StateMachineRegistry()
+                .withMachineBuilderConfigs(List.of(machineBuilderConfig2, machineBuilderConfig))
+                .withHub(machineBuilderConfig.getName(), TestHub.builder().build())
+                .withHub(machineBuilderConfig2.getName(), TestHub.builder().build())
+                .build();
+        Assert.assertNotNull(machineRegistry);
+        Assert.assertTrue(machineRegistry.getMachine("testMachine").isPresent());
+        Assert.assertTrue(machineRegistry.getMachine("testMachine2").isPresent());
+        Assert.assertTrue(machineRegistry.getMachine("testMachine3").isEmpty());
+    }
+}

--- a/src/test/java/com/grookage/fsm/core/helpers/ResourceHelper.java
+++ b/src/test/java/com/grookage/fsm/core/helpers/ResourceHelper.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2015 Koushik R <rkoushik.14@gmail.com>.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.grookage.fsm.core.helpers;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+
+public class ResourceHelper {
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    public static <T> T getResource(String path, Class<T> klass) throws IOException {
+        objectMapper.configure(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY, true);
+        final var data = ResourceHelper.class.getClassLoader().getResourceAsStream(path);
+        return objectMapper.readValue(data, klass);
+    }
+
+    public static <T> T getResource(String path, TypeReference<T> klass) throws IOException {
+        objectMapper.configure(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY, true);
+        final var data = ResourceHelper.class.getClassLoader().getResourceAsStream(path);
+        return objectMapper.readValue(data, klass);
+    }
+
+    public static ObjectMapper getObjectMapper() {
+        return objectMapper;
+    }
+}

--- a/src/test/java/com/grookage/fsm/core/helpers/StateMachineHelper.java
+++ b/src/test/java/com/grookage/fsm/core/helpers/StateMachineHelper.java
@@ -17,12 +17,7 @@ package com.grookage.fsm.core.helpers;
 
 import com.google.common.collect.Sets;
 import com.grookage.fsm.core.StateMachine;
-import com.grookage.fsm.core.stubs.TestContext;
-import com.grookage.fsm.core.stubs.TestEvent;
-import com.grookage.fsm.core.stubs.TestHub;
-import com.grookage.fsm.core.stubs.TestMachine;
-import com.grookage.fsm.core.stubs.TestState;
-import com.grookage.fsm.core.stubs.TestTransitionKey;
+import com.grookage.fsm.core.stubs.*;
 import lombok.experimental.UtilityClass;
 
 /**

--- a/src/test/java/com/grookage/fsm/core/services/ActionServiceTest.java
+++ b/src/test/java/com/grookage/fsm/core/services/ActionServiceTest.java
@@ -1,16 +1,12 @@
 package com.grookage.fsm.core.services;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.grookage.fsm.core.stubs.TestAction;
-import com.grookage.fsm.core.stubs.TestContext;
-import com.grookage.fsm.core.stubs.TestEvent;
-import com.grookage.fsm.core.stubs.TestState;
-import com.grookage.fsm.core.stubs.TestTransitionKey;
-import java.util.Map;
-import java.util.Optional;
-import java.util.function.Function;
+import com.grookage.fsm.core.stubs.*;
 import org.junit.Assert;
 import org.junit.Test;
+
+import java.util.Map;
+import java.util.Optional;
 
 public class ActionServiceTest {
 

--- a/src/test/java/com/grookage/fsm/core/services/StateManagementServiceTest.java
+++ b/src/test/java/com/grookage/fsm/core/services/StateManagementServiceTest.java
@@ -1,9 +1,10 @@
 package com.grookage.fsm.core.services;
 
 import com.grookage.fsm.core.stubs.TestState;
-import java.util.Set;
 import org.junit.Assert;
 import org.junit.Test;
+
+import java.util.Set;
 
 public class StateManagementServiceTest {
 

--- a/src/test/java/com/grookage/fsm/core/stubs/CompletedProcessor.java
+++ b/src/test/java/com/grookage/fsm/core/stubs/CompletedProcessor.java
@@ -1,6 +1,7 @@
 package com.grookage.fsm.core.stubs;
 
 import com.grookage.fsm.core.models.executors.TransitionProcessor;
+
 import java.util.Map;
 import java.util.Set;
 

--- a/src/test/java/com/grookage/fsm/core/stubs/FailedProcessor.java
+++ b/src/test/java/com/grookage/fsm/core/stubs/FailedProcessor.java
@@ -1,6 +1,7 @@
 package com.grookage.fsm.core.stubs;
 
 import com.grookage.fsm.core.models.executors.TransitionProcessor;
+
 import java.util.Map;
 import java.util.Set;
 

--- a/src/test/java/com/grookage/fsm/core/stubs/InProgressProcessor.java
+++ b/src/test/java/com/grookage/fsm/core/stubs/InProgressProcessor.java
@@ -1,6 +1,7 @@
 package com.grookage.fsm.core.stubs;
 
 import com.grookage.fsm.core.models.executors.TransitionProcessor;
+
 import java.util.Map;
 import java.util.Set;
 

--- a/src/test/java/com/grookage/fsm/core/stubs/InitiateProcessor.java
+++ b/src/test/java/com/grookage/fsm/core/stubs/InitiateProcessor.java
@@ -1,6 +1,7 @@
 package com.grookage.fsm.core.stubs;
 
 import com.grookage.fsm.core.models.executors.TransitionProcessor;
+
 import java.util.Map;
 import java.util.Set;
 

--- a/src/test/java/com/grookage/fsm/core/stubs/TestAction.java
+++ b/src/test/java/com/grookage/fsm/core/stubs/TestAction.java
@@ -1,8 +1,9 @@
 package com.grookage.fsm.core.stubs;
 
 import com.grookage.fsm.core.models.executors.EventAction;
-import java.util.Map;
 import lombok.Getter;
+
+import java.util.Map;
 
 @Getter
 public class TestAction implements EventAction<TestEvent, TestState, TestTransitionKey, TestContext> {

--- a/src/test/java/com/grookage/fsm/core/stubs/TestMachine.java
+++ b/src/test/java/com/grookage/fsm/core/stubs/TestMachine.java
@@ -14,6 +14,6 @@ public class TestMachine extends StateMachine<TestState, TestEvent, TestTransiti
       ErrorAction<TestEvent, TestState, TestTransitionKey, TestContext> errorAction,
       EventAction<TestEvent, TestState, TestTransitionKey, TestContext> eventAction
   ) {
-    super(startState, transitionProcessorHub, errorAction, eventAction);
+    super("test", startState, transitionProcessorHub, errorAction, eventAction);
   }
 }

--- a/src/test/resources/invalidMachine.json
+++ b/src/test/resources/invalidMachine.json
@@ -1,0 +1,22 @@
+{
+  "name" : "testMachine",
+  "startState" : "STARTED",
+  "endStates" : ["COMPLETED", "FAILED"],
+  "transitionConfigs" : [{
+    "from" : ["STARTED"],
+    "to" : "CREATED",
+    "causedEvent" : "INITIATE"
+  }, {
+    "from" : ["CREATED"],
+    "to" : "IN_PROGRESS",
+    "causedEvent" : "MOVE_TO_PROGRESS"
+  }, {
+    "from" : ["IN_PROGRESS"],
+    "to" : "COMPLETED",
+    "causedEvent" : "MOVE_TO_COMPLETED"
+  },  {
+    "from" : ["COMPLETED"],
+    "to" : "FAILED",
+    "causedEvent" : "MOVE_TO_FAILED"
+  }]
+}

--- a/src/test/resources/stateMachine.json
+++ b/src/test/resources/stateMachine.json
@@ -1,0 +1,22 @@
+{
+  "name" : "testMachine",
+  "startState" : "STARTED",
+  "endStates" : ["COMPLETED", "FAILED"],
+  "transitionConfigs" : [{
+    "from" : ["STARTED"],
+    "to" : "CREATED",
+    "causedEvent" : "INITIATE"
+  }, {
+    "from" : ["CREATED"],
+    "to" : "IN_PROGRESS",
+    "causedEvent" : "MOVE_TO_PROGRESS"
+  }, {
+    "from" : ["IN_PROGRESS"],
+    "to" : "COMPLETED",
+    "causedEvent" : "MOVE_TO_COMPLETED"
+  },  {
+    "from" : ["IN_PROGRESS"],
+    "to" : "FAILED",
+    "causedEvent" : "MOVE_TO_FAILED"
+  }]
+}

--- a/src/test/resources/stateMachine2.json
+++ b/src/test/resources/stateMachine2.json
@@ -1,0 +1,18 @@
+{
+  "name" : "testMachine2",
+  "startState" : "STARTED",
+  "endStates" : ["COMPLETED", "FAILED"],
+  "transitionConfigs" : [{
+    "from" : ["STARTED"],
+    "to" : "CREATED",
+    "causedEvent" : "INITIATE"
+  }, {
+    "from" : ["CREATED"],
+    "to" : "IN_PROGRESS",
+    "causedEvent" : "MOVE_TO_PROGRESS"
+  }, {
+    "from" : ["IN_PROGRESS"],
+    "to" : "COMPLETED",
+    "causedEvent" : "MOVE_TO_COMPLETED"
+  }]
+}


### PR DESCRIPTION
- Introduced a StateMachineBuilder to construct a stateMachine from a configuration, to reduce verbosity
- Introduced a StateMachineRegistry to create multiple stateMachines atop multiple MachineBuilderConfigurations, making multiple stateMachine creations simple.
- Introduced a CHANGELOG
- Added tests for the above features

Also addresses, [https://github.com/grookage/easy-fsm/pull/8](this)